### PR TITLE
++ ARKHIA_TESTNET_RELAY_ENDPOINT

### DIFF
--- a/tools/hardhat-example/.env.example
+++ b/tools/hardhat-example/.env.example
@@ -2,6 +2,7 @@
 OPERATOR_PRIVATE_KEY=0x105d050185ccb907fba04dd92d8de9e32c18305e097ab41dadda21489a211524
 RECEIVER_PRIVATE_KEY=0x2e1d968b041d84dd120a5860cee60cd83f9374ef527ca86996317ada3d0d03e7
 RELAY_ENDPOINT='http://localhost:7546'
+ARKHIA_TESTNET_RELAY_ENDPOINT='https://pool.hedera.testnet.arkhia.io/json-rpc/v1/{API_KEY_GOES_HERE}'
 
 # hedera global optionals
 TESTNET_DEV=0xPrivateKey

--- a/tools/hardhat-example/hardhat.config.ts
+++ b/tools/hardhat-example/hardhat.config.ts
@@ -97,7 +97,7 @@ const config = {
       ],
     },
     h_testnet: {
-      url: "https://testnet.hashio.io/api",
+      url: process.env.ARKHIA_TESTNET_RELAY_ENDPOINT || "https://testnet.hashio.io/api",
       chainId: 296,
       accounts: [process.env.DEPLOYER_TESTNET || "", process.env.TESTNET_DEV || ""],
       timeout: 60_000


### PR DESCRIPTION
Demo issue with arkhia json rpc relay.

Load the arkhia json rpc URL into .env and then run the `npm run test:hgf:testnet` to attempt to deploy and submit txs to contracts and observe the following issue:
```
[Request ID: d32a4ca9-32a2-4d11-bdd3-f4dae2382956] Requested resource not found. address '0xC6D338Ee543FcF8A4ecB3d1b97340556D9cac467'.
```